### PR TITLE
Format dataset iterator docstring

### DIFF
--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -103,8 +103,7 @@ class ListDataset:  # for training
         # self.rgb_std = np.array([69.095, 66.369, 64.236], dtype=np.float32).reshape((1, 3, 1, 1))
 
     def __iter__(self):
-        """Initializes iterator by resetting count, creating a shuffled vector of image numbers based on their weights.
-        """
+        """Initializes iterator by resetting count, creating a shuffled vector of image numbers based on their weights."""
         self.count = -1
         # self.shuffled_vector = np.random.permutation(self.nF)  # shuffled vector
         self.shuffled_vector = np.random.choice(

--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -103,8 +103,7 @@ class ListDataset:  # for training
         # self.rgb_std = np.array([69.095, 66.369, 64.236], dtype=np.float32).reshape((1, 3, 1, 1))
 
     def __iter__(self):
-        """Initializes iterator by resetting count, creating a shuffled vector of image numbers based on their weights.
-        """
+        """Reset count and sample a weighted shuffled image order."""
         self.count = -1
         # self.shuffled_vector = np.random.permutation(self.nF)  # shuffled vector
         self.shuffled_vector = np.random.choice(

--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -103,7 +103,8 @@ class ListDataset:  # for training
         # self.rgb_std = np.array([69.095, 66.369, 64.236], dtype=np.float32).reshape((1, 3, 1, 1))
 
     def __iter__(self):
-        """Initializes iterator by resetting count, creating a shuffled vector of image numbers based on their weights."""
+        """Initializes iterator by resetting count, creating a shuffled vector of image numbers based on their weights.
+        """
         self.count = -1
         # self.shuffled_vector = np.random.permutation(self.nF)  # shuffled vector
         self.shuffled_vector = np.random.choice(


### PR DESCRIPTION
## Summary
- Format the ListDataset iterator docstring onto one line for the Python formatting workflow.

## Tests
- `ruff check --fix --unsafe-fixes --extend-select F,I,D,UP,RUF,FA --target-version py39 --ignore D100,D104,D203,D205,D212,D213,D401,D406,D407,D413,RUF001,RUF002,RUF012 utils/datasets.py`
- `ruff format --line-length 120 utils/datasets.py`
- `python -m py_compile utils/datasets.py`
- `git diff --check`

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary
📝 This PR makes a small documentation-only improvement by clarifying how dataset iteration works in `utils/datasets.py`.

### 📊 Key Changes
- Updated the `__iter__` method docstring in `utils/datasets.py`.
- Replaced a longer, more awkward description with a clearer summary:
  - from explaining reset and weighted shuffle in a verbose way
  - to a concise description: reset count and sample a weighted shuffled image order
- No functional code logic was changed.

### 🎯 Purpose & Impact
- Improves code readability for contributors and maintainers 👀
- Makes the dataset loader behavior easier to understand at a glance
- Reduces ambiguity around how image ordering is handled during iteration
- Has no impact on training results, runtime behavior, or user-facing features ✅