### PR TITLE
Ruff 0.16.0 compatibility changes

### DIFF
--- a/utils/gcp.sh
+++ b/utils/gcp.sh
@@ -2,7 +2,7 @@
 # Ultralytics 🚀 AGPL-3.0 License - https://ultralytics.com/license
 
 # Start
-sudo rm -rf yolo && git clone https://github.com/ultralytics/yolo && cd yolo && python3  # from utils import utils; utils.createChips()
+sudo rm -rf yolo && git clone https://github.com/ultralytics/yolo && cd yolo && python3 # from utils import utils; utils.createChips()
 sudo rm -rf yolo && git clone https://github.com/ultralytics/yolo && cd yolo && python3 train.py -epochs 999
 sudo rm -rf mnist && git clone https://github.com/ultralytics/mnist && cd mnist && python3 train_xview_classes.py -name 'chips_20pad_square'
 
@@ -21,8 +21,7 @@ tar -xvzf train_images.tgz && sudo rm -rf train_images/._*
 # convert all .tif to .bmp
 sudo rm -rf yolo && git clone https://github.com/ultralytics/yolo && cd yolo
 
-python3
+python3 - << 'PY'
 from utils import datasets
 datasets.convert_tif2bmp('../train_images')
-exit()
-
+PY


### PR DESCRIPTION
Makes the legacy data-conversion block valid shell syntax so prettier-plugin-sh can parse and format it.\n\nValidation:\n- Ruff 0.16.0 check\n- bash syntax check\n- Prettier 3.6.2 with prettier-plugin-sh, clean second pass\n\nDeleted: interactive Python and exit statements replaced by the existing script-friendly heredoc form.

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

🛠️ Simplifies the xView data preparation workflow by replacing interactive Python commands with an automated script block.

### 📊 Key Changes

- Removed an extra space in the `utils/gcp.sh` Python command.
- Replaced the interactive `python3` session used for TIFF-to-BMP conversion with a here-document script.
- Automatically imports `datasets` and runs `datasets.convert_tif2bmp('../train_images')`.
- Removed the manual `exit()` command previously required to leave the Python shell.

### 🎯 Purpose & Impact

- 🚀 Makes the Google Cloud setup script fully non-interactive and easier to run automatically.
- ✅ Reduces the risk of setup pauses or user input errors during dataset conversion.
- 🔄 Preserves the existing workflow while improving scripting reliability for xView preprocessing.