### PR TITLE
Bump actions/stale from v10 to v11 in /.github/workflows

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -14,7 +14,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v10
+      - uses: actions/stale@v11
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           stale-issue-message: "This issue has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs. Thank you for your contributions."


### PR DESCRIPTION
Bump actions/stale from v10 to v11 in /.github/workflows

This PR updates GitHub Actions references in this repository.

Examples:
- Branch: `actions/checkout@main` stays on `@main`
- Major tag: `actions/checkout@v4` updates to `@v5`
- Specific tag: `astral-sh/setup-uv@v0.5.0` updates to `@v0.9.4`
- SHA pinned: `actions/checkout@<sha> # v4.1.0` updates to the latest release SHA and tag comment

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

## 🛠️ PR Summary

<sub>Made with ❤️ by [Ultralytics Actions](https://www.ultralytics.com/actions)</sub>

### 🌟 Summary

⬆️ Updates the stale issue management workflow from `actions/stale` v10 to v11.

### 📊 Key Changes

- Changes the GitHub Actions dependency in `.github/workflows/stale.yml` from `actions/stale@v10` to `actions/stale@v11`.
- Keeps the existing stale-issue configuration and messaging unchanged.

### 🎯 Purpose & Impact

- 🔒 Keeps the repository’s automated issue management workflow up to date.
- ⚙️ Applies improvements and maintenance updates included in `actions/stale` v11.
- ✅ No direct changes to model code, training, inference, or user-facing behavior.